### PR TITLE
Add dev qt package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:latest
 
-RUN apk add python3 py3-pip qt5-qtdeclarative
+RUN apk add python3 py3-pip qt5-qtdeclarative-dev
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt


### PR DESCRIPTION
I've been getting "Cannot find qmllint executable" errors since about yesterday. I was able to build this new Dockerfile and run `qmllint-qt5` to get the help text, so as far as I understand, this should fix the action.