### PR TITLE
Fix installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,7 @@
 
 FROM alpine:latest
 
-RUN apk add python3 py3-pip qt5-qtdeclarative-dev python3-dev build-base
-
-ADD requirements.txt /tmp/requirements.txt
-RUN pip3 install -r /tmp/requirements.txt
+RUN apk add python3 py3-pip qt5-qtdeclarative-dev python3-dev build-base py3-pygithub
 
 ADD entrypoint /
 ENTRYPOINT ["/entrypoint"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# SPDX-FileCopyrightText: 2020 Pier Luigi Fiorini <pierluigi.fiorini@liri.io>
-#
-# SPDX-License-Identifier: CC0-1.0
-
-PyGithub


### PR DESCRIPTION
The action build step is failing now. This is a result of the `alpine` update to 3.19.0 as latest. The accompanying `pip` version bumped from `23.1.2` to `23.3.1`. A feature of the newer pip version is to raise an error when trying to modify an externally managed environment, like exists in the docker container.

<details><summary>Here is the error output</summary>
<p>

```
#9 [4/5] RUN pip3 install -r /tmp/requirements.txt
  #9 1.947 error: externally-managed-environment
  #9 1.947 
  #9 1.947 × This environment is externally managed
  #9 1.947 ╰─> 
  #9 1.947     The system-wide python installation should be maintained using the system
  #9 1.947     package manager (apk) only.
  #9 1.947     
  #9 1.947     If the package in question is not packaged already (and hence installable via
  #9 1.947     "apk add py3-somepackage"), please consider installing it inside a virtual
  #9 1.947     environment, e.g.:
  #9 1.947     
  #9 1.947     python3 -m venv /path/to/venv
  #9 1.947     . /path/to/venv/bin/activate
  #9 1.947     pip install mypackage
  #9 1.947     
  #9 1.947     To exit the virtual environment, run:
  #9 1.947     
  #9 1.947     deactivate
  #9 1.947     
  #9 1.947     The virtual environment is not deleted, and can be re-entered by re-sourcing
  #9 1.947     the activate file.
  #9 1.947     
  #9 1.947     To automatically manage virtual environments, consider using pipx (from the
  #9 1.947     pipx package).
  #9 1.947 
  #9 1.947 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  #9 1.947 hint: See PEP 668 for the detailed specification.
  #9 ERROR: process "/bin/sh -c pip3 install -r /tmp/requirements.txt" did not complete successfully: exit code: 1
``` 

</p>
</details>

Since `apk add py3-pygithub` works, I figured I'd replace the requirements file and `pip install` step with adding that one dependency to the `apk add` step. I was able to build the new dockerfile and run `qmllint-qt5 --help` successfully, so I believe this fixes the issue.