### PR TITLE
Update to Qt6 and adjust entrypoint Python script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:latest
 
-RUN apk add python3 py3-pip qt5-qtdeclarative-dev python3-dev build-base py3-pygithub
+RUN apk add python3 py3-pip qt6-qtdeclarative-dev python3-dev build-base py3-pygithub
 
 ADD entrypoint /
 ENTRYPOINT ["/entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -35,10 +35,9 @@ def error(message, **kwargs):
 
 
 def find_qmllint():
-    for name in ('qmllint-qt5', 'qmllint'):
-        exe = shutil.which(name)
-        if exe is not None:
-            return exe
+    exe = shutil.which("/usr/lib/qt6/bin/qmllint")
+    if exe is not None:
+        return exe
     return None
 
 
@@ -52,12 +51,12 @@ def find_files(directory, pattern):
                 yield filename
 
 
-def lint(filename):
-    qmllint = find_qmllint()
-    if qmllint is None:
+def lint(filename, qmllint_bin):
+
+    if qmllint_bin is None:
         raise SystemExit('Cannot find qmllint executable')
 
-    result = subprocess.run([qmllint, filename], capture_output=True)
+    result = subprocess.run([qmllint_bin, filename], capture_output=True)
     if result.returncode != 0:
         errmsg = result.stderr.decode().strip()
         match = re.match('.+:(\d+) : (.+)', errmsg)
@@ -91,9 +90,12 @@ if __name__ == '__main__':
     if ci is False:
         update_status('pending', 'About to verify QML files')
 
+    qmllint_bin = find_qmllint()
+
     for suffix in ('qml', 'js'):
         for filename in Path('.').glob('**/*.' + suffix):
-            if lint(filename) is False:
+
+            if lint(filename, qmllint_bin) is False:
                 failed = True
 
     if failed is True:


### PR DESCRIPTION
Hello there :) 

We are using the qmllint-action in our project. Unfortunally we got some false positive, because we are using Qt6 and the qmllinter in this action is from Qt5. 

I update the Dockerfile, adjust the entrypoint script and modify it slightly, so that the qmllint bin is not "searched" every time a file is linted.